### PR TITLE
Node v0.12.2 deprecated method replaced

### DIFF
--- a/bufferjs/indexOf.js
+++ b/bufferjs/indexOf.js
@@ -13,7 +13,7 @@
     while (i<l) {
       var good = true;
       for (var j=0, n=needle.length; j<n; j++) {
-        if (haystack.get(i+j) !== needle.get(j)) {
+        if (haystack[i+j] !== needle[j]) {
           good = false;
           break;
         }


### PR DESCRIPTION
Using NodeJS v0.12.2 an error message is displayed

.get() is deprecated. Access using array indexes instead.

Line 16 changed to use the array method.

Untested with previous versions of node.
